### PR TITLE
feat(downloading form submissions): Form Owner can download a copy of the form submissions

### DIFF
--- a/src/pages/UserForms.tsx
+++ b/src/pages/UserForms.tsx
@@ -7,6 +7,7 @@ import { db } from "../styles/utils/firebase";
 import { Layout } from "../global.types";
 import ErrorBox from "../components/ErrorBox"
 import { Link } from "react-router";
+import { json2csv, handleCSVDownload } from "../utils/csv"
 
 type Form = {
   id: string;
@@ -14,6 +15,8 @@ type Form = {
   title: string;
   uid: string;
 }
+
+
 
 function UserForms() {
   const [forms, setForms] = useState<Form[]>([]);
@@ -36,6 +39,19 @@ function UserForms() {
     }
   }
 
+  const loadResponses = async (formId: string, formName: string) => {
+    try {
+      const submissionRef = collection(db, "submissions");
+      const q = query(submissionRef, where("formId", "==", formId));
+      const submissions = await getDocs(q);
+      const data = submissions.docs.map((doc: QueryDocumentSnapshot) => doc.data().response);
+      const csv= json2csv(data);
+      handleCSVDownload(csv,formName);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   useEffect(() => {
     loadForms();
   }, [user])
@@ -47,32 +63,31 @@ function UserForms() {
         {user ?
           <div className={styles.formList}>
             {forms.map((form: Form) => {
-              console.log(form);
               return (
                 <div key={form.id} className={styles.formContainer}>
                   <div>
                     <h3>{form.title}</h3>
                   </div>
                   <div>
-                    <Link className={styles.link} to="#">Submissions <svg viewBox="0 0 16 16" className={styles.linkIcon} xmlns="http://www.w3.org/2000/svg" version="1.1" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"></polyline> <path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"></path> </g></svg></Link>
+                    <button style={{ background: "none", border: "none" }} className={styles.link} onClick={() => loadResponses(form.id, form.title)}>Submissions <svg viewBox="0 0 16 16" className={styles.linkIcon} xmlns="http://www.w3.org/2000/svg" version="1.1" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"></polyline> <path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"></path> </g></svg></button>
                     <Link className={styles.link} to={`/forms/${form.id}`}>View Form <svg viewBox="0 0 16 16" className={styles.linkIcon} xmlns="http://www.w3.org/2000/svg" version="1.1" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"></polyline> <path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"></path> </g></svg></Link>
                   </div>
                 </div>
               )
             })}
             {
-              forms.length===0 && 
-               <div className={styles.formContainer}>
-                  <div>
-                    <h3>No forms pulished yet!</h3>
-                  </div>
-                  <div>
-                    <Link className={styles.link} to="/">Create a new form <svg viewBox="0 0 16 16" className={styles.linkIcon} xmlns="http://www.w3.org/2000/svg" version="1.1" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"></polyline> <path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"></path> </g></svg></Link>
-                  </div>
+              forms.length === 0 &&
+              <div className={styles.formContainer}>
+                <div>
+                  <h3>No forms pulished yet!</h3>
                 </div>
+                <div>
+                  <Link className={styles.link} to="/">Create a new form <svg viewBox="0 0 16 16" className={styles.linkIcon} xmlns="http://www.w3.org/2000/svg" version="1.1" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"> <polyline points="8.25 2.75,2.75 2.75,2.75 13.25,13.25 13.25,13.25 7.75"></polyline> <path d="m13.25 2.75-5.5 5.5m3-6.5h3.5v3.5"></path> </g></svg></Link>
+                </div>
+              </div>
             }
           </div> :
-          <ErrorBox error="Please login to view your forms."/>
+          <ErrorBox error="Please login to view your forms." />
         }
       </main>
     </div>

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,31 @@
+
+export const json2csv= (data : Array<any>)=>{
+
+    if(data===undefined || data.length===0) return "No submissions yet";
+
+    const headers= Object.keys(data[0]).map((key:string)=>key);
+
+    const res=[headers.join(",")];
+    
+    data.forEach((item)=>{
+        
+        const values= headers.map(header=>{
+            const val= item[header] ?? "";
+            return `"${val.toString().replace(/"/g, '""')}"`;
+        })
+        res.push(values.join(","));
+    })
+    return res.join("\n");
+}
+
+export const handleCSVDownload= (csv:string, filename: string)=>{
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+}


### PR DESCRIPTION
# Summary
- The Form Owner only can access the forms list.
- On click of a button, the submissions stored in the firestore will be converted into csv format and downloaded on his machine.
- All the process happen over client browser.

# Changes
- Added a "src/utils/csv.ts" file for exporting and defining the "json2Csv" and "handleCsvDownload" method.
- Implemented manual logic to convert and blob download. Reducing dependency overhead.

